### PR TITLE
Use GH org var for DOCKERHUB_USERNAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Docker metadata action


### PR DESCRIPTION
Related ticket: CIV-740

Use GH org var for `DOCKERHUB_USERNAME` as secret is unnecessary